### PR TITLE
Added support for strings 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+build/*
+
+*.o
+
+src/host/
+src/tree/
+
+*.out
+*.out.c

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "cmake-common"]
+	path = cmake-common
+	url = https://github.com/SacBase/cmake-common.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,43 @@
+CMAKE_MINIMUM_REQUIRED (VERSION 3.3)
+
+PROJECT (sac-jsonmodule)
+
+# Where the compiled sac modules result
+SET (DLL_BUILD_DIR "${PROJECT_BINARY_DIR}/lib")
+
+# For what targets we build modules
+SET (TARGETS      seq mt_pth  CACHE STRING "Build stdlib-cuda for these targets")
+SET (SAC2C_EXEC               CACHE STRING "A path to sac2c compiler")
+SET (LINKSETSIZE  "0"         CACHE STRING "Set a value for -linksetsize parameter of sac2c")
+
+# Check whether sac2c is operational
+INCLUDE ("cmake-common/check-sac2c.cmake")
+INCLUDE ("cmake-common/misc-macros.cmake")
+
+# add our custom Find*.cmake
+LIST (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
+# Ensure cJSON is available
+FIND_PACKAGE (cJSON REQUIRED)
+
+SET (SAC2C_EXTRA_INC "-I${CJSON_INCLUDE_DIR}" CACHE STRING "Extra include files that should be used by sac2c")
+
+# if building generically, we need to make sure sac2c supports this
+IF (BUILDGENERIC)
+    CHECK_SAC2C_SUPPORT_FLAG ("generic" "-generic")
+    IF (HAVE_FLAG_generic)
+        LIST (APPEND SAC2C_CPP_INC "-generic")
+        MESSAGE (STATUS "Building with *no* system-specific optimisations.")
+    ELSE ()
+        MESSAGE (STATUS "Generic-build disabled as sac2c does not support this!")
+        SET (BUILDGENERIC OFF)
+    ENDIF ()
+ENDIF ()
+
+# For every target run CMakeLists.txt in src
+FOREACH (TARGET IN ITEMS ${TARGETS})
+  	ADD_SUBDIRECTORY (src src-${TARGET})
+ENDFOREACH ()
+
+# This build target is responsible for generating the package sac2crc file
+CREATE_SAC2CRC_TARGET ("jsonmodule" "${DLL_BUILD_DIR}" "${DLL_BUILD_DIR}" "-lcjson")

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
-# JSON
-Provides support for JASON
+# SAC JSON Module
+## About
+This is a Sac module that wraps around some of the [cJSON](https://github.com/DaveGamble/cJSON) library. Currently this is a work in progress.
+## Build Instructions
+You'll need to have installed sac2c and have a copy of the Stdlib installed as well.
+```bash
+cd JSON
+git submodule init
+git submodule update
+cd build
+cmake ..
+make -j4
+```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # SAC JSON Module
 ## About
 This is a Sac module that wraps around some of the [cJSON](https://github.com/DaveGamble/cJSON) library. Currently this is a work in progress.
+
+## Supported Functionality
+- Creating of empty json object.
+- Adding booleans to json objects.
+- Serializing json objects to stdout.
+
 ## Build Instructions
 You'll need to have installed sac2c and have a copy of the Stdlib installed as well.
 ```bash

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This is a Sac module that wraps around some of the [cJSON](https://github.com/Da
 - Adding integers to json objects.
 - Adding floats to json objects.
 - Adding doubles to json objects.
+- Adding strings to json objects.
 - Serializing json objects to stdout.
 
 ## Build Instructions

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ This is a Sac module that wraps around some of the [cJSON](https://github.com/Da
 ## Supported Functionality
 - Creating of empty json object.
 - Adding booleans to json objects.
+- Adding integers to json objects.
+- Adding floats to json objects.
+- Adding doubles to json objects.
 - Serializing json objects to stdout.
 
 ## Build Instructions

--- a/cmake/FindcJSON.cmake
+++ b/cmake/FindcJSON.cmake
@@ -1,0 +1,18 @@
+# CMake module to search for the cJSON library
+# (library for printing JSON files)
+#
+# If it's found it sets CJSON_FOUND to TRUE
+# and following variables are set:
+#    CJSON_INCLUDE_DIR
+#    CJSON_LIBRARIES
+
+FIND_PATH(CJSON_INCLUDE_DIR NAMES cjson/cJSON.h)
+FIND_LIBRARY(CJSON_LIBRARIES NAMES cjson)
+
+INCLUDE(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(
+	cJSON 
+	DEFAULT_MSG CJSON_LIBRARIES 
+	CJSON_INCLUDE_DIR
+)
+MARK_AS_ADVANCED(CJSON_INCLUDE_DIR CJSON_LIBRARIES)

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,14 @@
+# Examples
+## How to Run?
+```bash
+sac2c FILENAME.sac
+./a.out
+```
+## Files
+### `printing_json.sac`
+Creates an empty json object and outputs it to stdout.
+expected result:
+```bash
+{
+}
+```

--- a/examples/README.md
+++ b/examples/README.md
@@ -25,3 +25,15 @@ expected result:
 	"isAlsoFalse":	false
 }
 ```
+
+### `printing_json_numbers.sac`
+Creates a json object and sets numbers in various ways (int, float, double).
+Then outputs the json object to stdout.
+expected result:
+```json
+{
+	"integer":	42,
+	"float":	1.2000000476837158,
+	"double":	3.4
+}
+```

--- a/examples/README.md
+++ b/examples/README.md
@@ -37,3 +37,13 @@ expected result:
 	"double":	3.4
 }
 ```
+
+### `printing_json_string.sac`
+Creates a json object and sets a string.
+Then outputs the json object to stdout.
+expected result:
+```json
+{
+	"aString":	"Hello World!"
+}
+```

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,10 +5,23 @@ sac2c FILENAME.sac
 ./a.out
 ```
 ## Files
-### `printing_json.sac`
+### `printing_json_empty.sac`
 Creates an empty json object and outputs it to stdout.
 expected result:
-```bash
+```json
 {
+}
+```
+
+### `printing_json_booleans.sac`
+Creates a json object and sets some booleans in various ways.
+Then outputs the json object to stdout.
+expected result:
+```json
+{
+	"isTrue":		true,
+	"isFalse":		false,
+	"isAlsoTrue":	true,
+	"isAlsoFalse":	false
 }
 ```

--- a/examples/printing_json.sac
+++ b/examples/printing_json.sac
@@ -1,0 +1,9 @@
+use StdIO: all;
+use JSON: all;
+
+int main()
+{
+	json_object = createJSONObject();
+	serializeJSONObject(json_object);
+	return 0;
+}

--- a/examples/printing_json.sac
+++ b/examples/printing_json.sac
@@ -1,9 +1,0 @@
-use StdIO: all;
-use JSON: all;
-
-int main()
-{
-	json_object = createJSONObject();
-	serializeJSONObject(json_object);
-	return 0;
-}

--- a/examples/printing_json_booleans.sac
+++ b/examples/printing_json_booleans.sac
@@ -1,0 +1,13 @@
+use StdIO: all;
+use JSON: all;
+
+int main()
+{
+	json_object = createJSONObject();
+	setBool(json_object, "isTrue", true);
+	setBool(json_object, "isFalse", false);
+	setTrue(json_object, "isAlsoTrue");
+	setFalse(json_object, "isAlsoFalse");
+	serializeJSONObject(json_object);
+	return 0;
+}

--- a/examples/printing_json_empty.sac
+++ b/examples/printing_json_empty.sac
@@ -1,0 +1,13 @@
+use StdIO: all;
+use JSON: all;
+
+int main()
+{
+	json_object = createJSONObject();
+	setBool(json_object, "isTrue", true);
+	setBool(json_object, "isFalse", false);
+	setTrue(json_object, "isAlsoTrue");
+	setFalse(json_object, "isAlsoFalse");
+	serializeJSONObject(json_object);
+	return 0;
+}

--- a/examples/printing_json_empty.sac
+++ b/examples/printing_json_empty.sac
@@ -4,10 +4,6 @@ use JSON: all;
 int main()
 {
 	json_object = createJSONObject();
-	setBool(json_object, "isTrue", true);
-	setBool(json_object, "isFalse", false);
-	setTrue(json_object, "isAlsoTrue");
-	setFalse(json_object, "isAlsoFalse");
 	serializeJSONObject(json_object);
 	return 0;
 }

--- a/examples/printing_json_numbers.sac
+++ b/examples/printing_json_numbers.sac
@@ -1,0 +1,22 @@
+use StdIO: all;
+use JSON: all;
+
+int main()
+{
+	json_object = createJSONObject();
+	setInt(json_object, "integer", 42);
+	setFloat(json_object, "float", 1.2f);
+	setDouble(json_object, "double", 3.4);
+	serializeJSONObject(json_object);
+	return 0;
+}
+
+// float getFloat()
+// {
+// 	return 1.2f;
+// }
+
+// double getDouble()
+// {
+// 	return 3.4;
+// }

--- a/examples/printing_json_numbers.sac
+++ b/examples/printing_json_numbers.sac
@@ -10,13 +10,3 @@ int main()
 	serializeJSONObject(json_object);
 	return 0;
 }
-
-// float getFloat()
-// {
-// 	return 1.2f;
-// }
-
-// double getDouble()
-// {
-// 	return 3.4;
-// }

--- a/examples/printing_json_string.sac
+++ b/examples/printing_json_string.sac
@@ -1,0 +1,10 @@
+use StdIO: all;
+use JSON: all;
+
+int main()
+{
+	json_object = createJSONObject();
+	setString(json_object, "aString", "Hello World!");
+	serializeJSONObject(json_object);
+	return 0;
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,79 @@
+CMAKE_MINIMUM_REQUIRED (VERSION 3.3)
+INCLUDE ("${CMAKE_SOURCE_DIR}/cmake-common/sac2c-variables.cmake")
+INCLUDE ("${CMAKE_SOURCE_DIR}/cmake-common/resolve-sac2c-dependencies.cmake")
+
+# C files relatively to this CMakeLists.txt.
+SET (C_DEPS_SRC
+  src/JSONBuilder/json_builder.c
+  src/JSONObject/delete_json_object.c
+)
+
+# SaC files relatively to this CMakeLists.txt.
+SET (SAC_SRC
+  JSONBuilder.sac
+  JSONObject.sac
+  JSON.sac
+)
+
+# For every C source, compile an object file maintaining the right location
+# in the binary dir so that sac files can pick it up.
+
+FOREACH (name ${C_DEPS_SRC})
+  SET (src "${CMAKE_CURRENT_SOURCE_DIR}/${name}")
+  GET_FILENAME_COMPONENT (dir ${name} DIRECTORY)
+  GET_FILENAME_COMPONENT (dst ${name} NAME_WE)
+  SET (dst "${CMAKE_CURRENT_BINARY_DIR}/${dir}/${dst}${OBJEXT}")
+
+  # Make sure that we put the object file in the same location where
+  # the source file was.
+  FILE (MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/${dir}")
+
+  ADD_CUSTOM_COMMAND (
+    OUTPUT "${dst}"
+    MAIN_DEPENDENCY "${src}"
+    IMPLICIT_DEPENDS C "${src}"
+    COMMAND ${SAC2C} -v0 -noprelude -cc ccmod -o "${dst}" "${src}"
+    COMMENT "Generating ${dst}"
+  )
+ENDFOREACH (name)
+
+# Make a directory for sac2c output
+FILE (MAKE_DIRECTORY "${DLL_BUILD_DIR}/${TARGET_ENV}/${SBI}")
+
+# For every sac file, compile Tree and Mod files.
+FOREACH (name ${SAC_SRC})
+  SET (src "${CMAKE_CURRENT_SOURCE_DIR}/${name}")
+  # sac2c requires computes objectfiles relatively to the working directory
+  # of the call to sac2c.
+  GET_FILENAME_COMPONENT (dir "${CMAKE_CURRENT_BINARY_DIR}/${name}" DIRECTORY)
+  GET_FILENAME_COMPONENT (dst ${name} NAME_WE)
+  SET (mod "${DLL_BUILD_DIR}/${TARGET_ENV}/${SBI}/lib${dst}Mod${MODEXT}")
+  SET (tree "${DLL_BUILD_DIR}/tree/${TARGET_ENV}/lib${dst}Tree${TREE_DLLEXT}")
+
+  RESOLVE_SAC_DEPENDENCIES ("${name}" "${SAC_SRC}" moddep_list)
+
+  MESSAGE ("dependencies of ${name} => `${moddep_list}'")
+
+  ADD_CUSTOM_COMMAND (
+    OUTPUT ${mod} ${tree}
+    COMMAND ${SAC2C} -v0 -linksetsize ${LINKSETSIZE} -o ${DLL_BUILD_DIR} ${src}
+    WORKING_DIRECTORY ${dir}
+    DEPENDS ${moddep_list}
+    COMMENT "Building ${name} module for target `${TARGET}'"
+  )
+
+  # Install compiled Tree/Mod parts of the compiled module
+  # to the corresponding locations.
+  INSTALL (
+    FILES ${mod}
+    DESTINATION ${INSTALL_MOD_DIR}/${TARGET_ENV}/${SBI}
+  )
+  INSTALL (
+    FILES ${tree}
+    DESTINATION ${INSTALL_TREE_DIR}/tree/${TARGET_ENV}
+  )
+
+  # Make a call to the command that compiles the module a part
+  # of the default build process.
+  ADD_CUSTOM_TARGET (${TARGET}-module-${dst} ALL DEPENDS ${mod} ${tree})
+ENDFOREACH (name)

--- a/src/JSON.sac
+++ b/src/JSON.sac
@@ -1,0 +1,6 @@
+module JSON;
+
+import JSONBuilder: all;
+import JSONObject: all;
+
+export all;

--- a/src/JSONBuilder.sac
+++ b/src/JSONBuilder.sac
@@ -11,6 +11,7 @@ external JSONObject createJSONObject();
 	#pragma linkobj "src/JSONBuilder/json_builder.o"
 	#pragma linksign [0]
 
+// Booleans
 external void setBool( JSONObject& object, string key, bool boolean);
 	#pragma linkname "set_bool"
 	#pragma linkobj "src/JSONBuilder/json_builder.o"
@@ -25,6 +26,20 @@ external void setFalse( JSONObject& object, string key);
 	#pragma linkname "set_false"
 	#pragma linkobj "src/JSONBuilder/json_builder.o"
 	#pragma linksign [1, 2]
+
+// Numbers
+external void setInt( JSONObject& object, string key, int value);
+	#pragma linkname "set_int"
+	#pragma linkobj "src/JSONBuilder/json_builder.o"
+	#pragma linksign [1, 2, 3]
+external void setFloat( JSONObject& object, string key, float value);
+	#pragma linkname "set_float"
+	#pragma linkobj "src/JSONBuilder/json_builder.o"
+	#pragma linksign [1, 2, 3]
+external void setDouble( JSONObject& object, string key, double value);
+	#pragma linkname "set_double"
+	#pragma linkobj "src/JSONBuilder/json_builder.o"
+	#pragma linksign [1, 2, 3]
 
 external void serializeJSONObject( JSONObject& object);
 	#pragma effect TheTerminal

--- a/src/JSONBuilder.sac
+++ b/src/JSONBuilder.sac
@@ -41,6 +41,12 @@ external void setDouble( JSONObject& object, string key, double value);
 	#pragma linkobj "src/JSONBuilder/json_builder.o"
 	#pragma linksign [1, 2, 3]
 
+// String
+external void setString( JSONObject& object, string key, string value);
+	#pragma linkname "set_string"
+	#pragma linkobj "src/JSONBuilder/json_builder.o"
+	#pragma linksign [1, 2, 3]
+
 external void serializeJSONObject( JSONObject& object);
 	#pragma effect TheTerminal
 	#pragma linkname "serialize_object"

--- a/src/JSONBuilder.sac
+++ b/src/JSONBuilder.sac
@@ -1,0 +1,17 @@
+module JSONBuilder;
+
+use JSONObject: all;
+use Terminal: {TheTerminal};
+
+export all;
+
+external JSONObject createJSONObject();
+	#pragma linkname "create_object"
+	#pragma linkobj "src/JSONBuilder/json_builder.o"
+	#pragma linksign [0]
+
+external void serializeJSONObject( JSONObject& object);
+	#pragma effect TheTerminal
+	#pragma linkname "serialize_object"
+	#pragma linkobj "src/JSONBuilder/json_builder.o"
+	#pragma linksign [1]

--- a/src/JSONBuilder.sac
+++ b/src/JSONBuilder.sac
@@ -1,6 +1,7 @@
 module JSONBuilder;
 
 use JSONObject: all;
+use String: {string};
 use Terminal: {TheTerminal};
 
 export all;
@@ -9,6 +10,21 @@ external JSONObject createJSONObject();
 	#pragma linkname "create_object"
 	#pragma linkobj "src/JSONBuilder/json_builder.o"
 	#pragma linksign [0]
+
+external void setBool( JSONObject& object, string key, bool boolean);
+	#pragma linkname "set_bool"
+	#pragma linkobj "src/JSONBuilder/json_builder.o"
+	#pragma linksign [1, 2, 3]
+
+external void setTrue( JSONObject& object, string key);
+	#pragma linkname "set_true"
+	#pragma linkobj "src/JSONBuilder/json_builder.o"
+	#pragma linksign [1, 2]
+
+external void setFalse( JSONObject& object, string key);
+	#pragma linkname "set_false"
+	#pragma linkobj "src/JSONBuilder/json_builder.o"
+	#pragma linksign [1, 2]
 
 external void serializeJSONObject( JSONObject& object);
 	#pragma effect TheTerminal

--- a/src/JSONObject.sac
+++ b/src/JSONObject.sac
@@ -1,0 +1,7 @@
+class JSONObject;
+
+external classtype;
+	#pragma freefun "delete_json_object"
+	#pragma linkobj "src/JSONObject/delete_json_object.o"
+
+export all;

--- a/src/src/JSONBuilder/json_builder.c
+++ b/src/src/JSONBuilder/json_builder.c
@@ -1,9 +1,27 @@
 #include <cjson/cJSON.h>
+#include <stdbool.h>
 #include <stdio.h>
 
 cJSON * create_object()
 {
 	return cJSON_CreateObject();
+}
+
+void set_bool( cJSON * object, char * key, bool boolean)
+{
+	cJSON * val;
+	val = boolean ? cJSON_CreateTrue() : cJSON_CreateFalse();
+	cJSON_AddItemToObject(object, key, val);
+}
+
+void set_true( cJSON * object, char * key) 
+{
+	set_bool(object, key, true);
+}
+
+void set_false( cJSON * object, char * key) 
+{
+	set_bool(object, key, false);
 }
 
 void serialize_object( cJSON* object)

--- a/src/src/JSONBuilder/json_builder.c
+++ b/src/src/JSONBuilder/json_builder.c
@@ -7,21 +7,40 @@ cJSON * create_object()
 	return cJSON_CreateObject();
 }
 
+// Booleans
 void set_bool( cJSON * object, char * key, bool boolean)
 {
 	cJSON * val;
 	val = boolean ? cJSON_CreateTrue() : cJSON_CreateFalse();
 	cJSON_AddItemToObject(object, key, val);
 }
-
 void set_true( cJSON * object, char * key) 
 {
 	set_bool(object, key, true);
 }
-
 void set_false( cJSON * object, char * key) 
 {
 	set_bool(object, key, false);
+}
+
+// Numbers
+void set_int( cJSON * object, char * key, int value)
+{
+	cJSON * val;
+	val = cJSON_CreateNumber(value);
+	cJSON_AddItemToObject(object, key, val);
+}
+void set_float( cJSON * object, char * key, float value)
+{
+	cJSON * val;
+	val = cJSON_CreateNumber((double)value);
+	cJSON_AddItemToObject(object, key, val);
+}
+void set_double( cJSON * object, char * key, double value)
+{
+	cJSON * val;
+	val = cJSON_CreateNumber(value);
+	cJSON_AddItemToObject(object, key, val);
 }
 
 void serialize_object( cJSON* object)

--- a/src/src/JSONBuilder/json_builder.c
+++ b/src/src/JSONBuilder/json_builder.c
@@ -1,0 +1,14 @@
+#include <cjson/cJSON.h>
+#include <stdio.h>
+
+cJSON * create_object()
+{
+	return cJSON_CreateObject();
+}
+
+void serialize_object( cJSON* object)
+{
+	char * str;
+	str = cJSON_Print(object);
+	printf("%s\n", str);
+}

--- a/src/src/JSONBuilder/json_builder.c
+++ b/src/src/JSONBuilder/json_builder.c
@@ -43,6 +43,14 @@ void set_double( cJSON * object, char * key, double value)
 	cJSON_AddItemToObject(object, key, val);
 }
 
+// String
+void set_string( cJSON * object, char * key, char * value)
+{
+	cJSON * val;
+	val = cJSON_CreateString(value);
+	cJSON_AddItemToObject(object, key, val);
+}
+
 void serialize_object( cJSON* object)
 {
 	char * str;

--- a/src/src/JSONObject/delete_json_object.c
+++ b/src/src/JSONObject/delete_json_object.c
@@ -1,0 +1,6 @@
+#include <cjson/cJSON.h>
+
+void delete_json_object( cJSON * object)
+{
+	cJSON_Delete( object);
+}


### PR DESCRIPTION
Added:
- `setString` function allows adding a string to the specified json object
- `examples/printing_json_string.sac` demonstrating new functionality

Changed:
- `examples/README` reflecting new functionality
- `README` reflecting new functionality